### PR TITLE
Endpoint Naming Consistency

### DIFF
--- a/Duo.Api/Controllers/CoinsController.cs
+++ b/Duo.Api/Controllers/CoinsController.cs
@@ -13,7 +13,7 @@ namespace Duo.Api.Controllers
     {
         #region Methods
 
-        [HttpGet("balance/{userId}")]
+        [HttpGet("get-balance/{userId}")]
         public async Task<ActionResult<int>> GetUserCoinBalance(int userId)
         {
             try
@@ -29,7 +29,7 @@ namespace Duo.Api.Controllers
             }
         }
 
-        [HttpPost("spend")]
+        [HttpPost("add-spent-coins")]
         public async Task<ActionResult> SpendCoins([FromBody] SpendCoinsRequest request)
         {
             try
@@ -67,7 +67,7 @@ namespace Duo.Api.Controllers
             }
         }
 
-        [HttpPost("dailybonus")]
+        [HttpPost("get-dailybonus")]
         public async Task<ActionResult> ApplyDailyLoginBonus([FromBody] DailyBonusRequest request)
         {
             try

--- a/Duo.Api/Controllers/ExamController.cs
+++ b/Duo.Api/Controllers/ExamController.cs
@@ -55,7 +55,7 @@ namespace Duo.Api.Controllers
         /// </summary>
         /// <param name="id">The ID of the exam to retrieve.</param>
         /// <returns>The exam if found; otherwise, NotFound.</returns>
-        [HttpGet("get")]
+        [HttpGet("get-exam-by-id")]
         public async Task<IActionResult> GetExam([FromQuery] int id)
         {
             try
@@ -108,7 +108,7 @@ namespace Duo.Api.Controllers
         /// Lists all exams in the database.
         /// </summary>
         /// <returns>A list of all exams.</returns>
-        [HttpGet("list")]
+        [HttpGet("get-all")]
         public async Task<IActionResult> ListExams()
         {
             try
@@ -236,7 +236,7 @@ namespace Duo.Api.Controllers
         /// </summary>
         /// <param name="sectionId">The ID of the section.</param>
         /// <returns>The exam if found; otherwise, NotFound.</returns>
-        [HttpGet("get-from-section")]
+        [HttpGet("get-exams-from-section")]
         public async Task<IActionResult> GetExamFromSection([FromQuery] int sectionId)
         {
             try
@@ -259,7 +259,7 @@ namespace Duo.Api.Controllers
         /// Retrieves all available exams.
         /// </summary>
         /// <returns>A list of available exams.</returns>
-        [HttpGet("get-available")]
+        [HttpGet("get-all-available")]
         public async Task<IActionResult> GetAvailableExams()
         {
             try

--- a/Duo.Api/Controllers/ExerciseController.cs
+++ b/Duo.Api/Controllers/ExerciseController.cs
@@ -31,7 +31,7 @@ namespace Duo.Api.Controllers
         /// Retrieves all exercises from the database.
         /// </summary>
         /// <returns>A list of all exercises.</returns>
-        [HttpGet]
+        [HttpGet("get-all")]
         public async Task<ActionResult<List<Exercise>>> GetAllExercisesAsync()
         {
             try
@@ -51,7 +51,7 @@ namespace Duo.Api.Controllers
         /// </summary>
         /// <param name="id">The ID of the exercise to retrieve.</param>
         /// <returns>The exercise if found; otherwise, NotFound.</returns>
-        [HttpGet("{id}", Name = "GetExerciseById")]
+        [HttpGet("get-exercise-by-id")]
         public async Task<ActionResult<Exercise>> GetByIdAsync(int id)
         {
             if (id <= 0)
@@ -87,7 +87,7 @@ namespace Duo.Api.Controllers
         /// </summary>
         /// <param name="quizId">The ID of the quiz.</param>
         /// <returns>A list of exercises associated with the quiz.</returns>
-        [HttpGet("quiz/{quizId}")]
+        [HttpGet("get-exercises-by-quiz/{quizId}")]
         public async Task<ActionResult<List<Exercise>>> GetQuizExercises(int quizId)
         {
             if (quizId <= 0)
@@ -129,7 +129,7 @@ namespace Duo.Api.Controllers
         /// </summary>
         /// <param name="examId">The ID of the exam.</param>
         /// <returns>A list of exercises associated with the exam.</returns>
-        [HttpGet("exam/{examId}")]
+        [HttpGet("get-exercises-by-exam/{examId}")]
         public async Task<ActionResult<List<Exercise>>> GetExamExercises(int examId)
         {
             if (examId <= 0)
@@ -171,7 +171,7 @@ namespace Duo.Api.Controllers
         /// </summary>
         /// <param name="exercise">The exercise to add.</param>
         /// <returns>The created exercise.</returns>
-        [HttpPost]
+        [HttpPost("add")]
         public async Task<ActionResult> AddExercise([FromBody] JsonElement rawJson)
         {
 
@@ -239,7 +239,7 @@ namespace Duo.Api.Controllers
         /// </summary>
         /// <param name="id">The ID of the exercise to delete.</param>
         /// <returns>NoContent if deleted; otherwise, NotFound.</returns>
-        [HttpDelete("{id}")]
+        [HttpDelete("delete/{id}")]
         public async Task<ActionResult> DeleteExercise(int id)
         {
             if (id <= 0)

--- a/Duo.Api/Controllers/ModuleController.cs
+++ b/Duo.Api/Controllers/ModuleController.cs
@@ -100,7 +100,7 @@ namespace Duo.Api.Controllers
         /// </summary>
         /// <param name="id">The ID of the module to remove.</param>
         /// <returns>ActionResult with operation result.</returns>
-        [HttpDelete("{id}")]
+        [HttpDelete("delete/{id}")]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
@@ -128,7 +128,7 @@ namespace Duo.Api.Controllers
         /// </summary>
         /// <param name="id">The ID of the module to retrieve.</param>
         /// <returns>ActionResult with the module data or error message.</returns>
-        [HttpGet("{id}")]
+        [HttpGet("get-module-by-id/{id}")]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
@@ -154,7 +154,7 @@ namespace Duo.Api.Controllers
         /// Gets a list of all modules in the system.
         /// </summary>
         /// <returns>ActionResult with list of modules or error message.</returns>
-        [HttpGet("list")]
+        [HttpGet("get-all")]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> ListModules()
@@ -178,7 +178,7 @@ namespace Duo.Api.Controllers
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
-        [HttpGet("list/by-course/{courseId}")]
+        [HttpGet("get-all/by-course/{courseId}")]
         public async Task<IActionResult> ListModulesByCourseId([FromRoute] int courseId)
         {
             try
@@ -200,7 +200,7 @@ namespace Duo.Api.Controllers
         /// <param name="id">The ID of the module to update.</param>
         /// <param name="request">The updated module data.</param>
         /// <returns>ActionResult with operation result.</returns>
-        [HttpPatch("{id}")]
+        [HttpPatch("modify/{id}")]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
@@ -236,7 +236,7 @@ namespace Duo.Api.Controllers
         /// <param name="userId">The ID of the user.</param>
         /// <param name="moduleId">The ID of the module.</param>
         /// <returns>True if completed, false otherwise.</returns>
-        [HttpGet("is-completed")]
+        [HttpGet("get-completion-status")]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> IsModuleCompleted([FromQuery] int userId, [FromQuery] int moduleId)
@@ -252,7 +252,7 @@ namespace Duo.Api.Controllers
             }
         }
 
-        [HttpPost("open")]
+        [HttpPost("add-open-module")]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> OpenModule([FromBody] OpenModuleRequest request)
@@ -274,7 +274,7 @@ namespace Duo.Api.Controllers
             }
         }
 
-        [HttpGet("isOpen")]
+        [HttpGet("get-open-status")]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> IsModuleOpen([FromQuery] int userId, [FromQuery] int moduleId)

--- a/Duo.Api/Controllers/QuizController.cs
+++ b/Duo.Api/Controllers/QuizController.cs
@@ -51,7 +51,7 @@ namespace Duo.Api.Controllers
         /// <summary>
         /// Retrieves a quiz by its ID.
         /// </summary>
-        [HttpGet("get")]
+        [HttpGet("get-quiz-by-id")]
         public async Task<IActionResult> GetQuiz([FromQuery] int id)
         {
             try
@@ -103,7 +103,7 @@ namespace Duo.Api.Controllers
         /// <summary>
         /// Lists all quizzes in the database.
         /// </summary>
-        [HttpGet("list")]
+        [HttpGet("get-all")]
         public async Task<IActionResult> ListQuizzes()
         {
             try
@@ -142,7 +142,7 @@ namespace Duo.Api.Controllers
         /// <summary>
         /// Updates an existing quiz.
         /// </summary>
-        [HttpPut("update")]
+        [HttpPut("modify")]
         public async Task<IActionResult> UpdateQuiz([FromForm] Quiz updatedQuiz)
         {
             try
@@ -188,7 +188,7 @@ namespace Duo.Api.Controllers
         /// <summary>
         /// Retrieves all quizzes from a specific section.
         /// </summary>
-        [HttpGet("get-all-section")]
+        [HttpGet("get-all-by-section")]
         public async Task<IActionResult> GetAllQuizzesFromSection([FromQuery] int sectionId)
         {
             try
@@ -205,7 +205,7 @@ namespace Duo.Api.Controllers
         /// <summary>
         /// Retrieves the number of quizzes in a specific section.
         /// </summary>
-        [HttpGet("count-from-section")]
+        [HttpGet("count-quizzes-from-section")]
         public async Task<IActionResult> CountQuizzesFromSection([FromQuery] int sectionId)
         {
             try
@@ -222,7 +222,7 @@ namespace Duo.Api.Controllers
         /// <summary>
         /// Retrieves the last order number from a specific section.
         /// </summary>
-        [HttpGet("last-order")]
+        [HttpGet("get-last-order-number-from-section")]
         public async Task<IActionResult> GetLastOrderNumberFromSection([FromQuery] int sectionId)
         {
             try
@@ -273,7 +273,7 @@ namespace Duo.Api.Controllers
         /// <summary>
         /// Removes an exercise from a quiz.
         /// </summary>
-        [HttpDelete("remove-exercise")]
+        [HttpDelete("delete-exercise")]
         public async Task<IActionResult> RemoveExerciseFromQuiz([FromQuery] int quizId, [FromQuery] int exerciseId)
         {
             try
@@ -290,7 +290,7 @@ namespace Duo.Api.Controllers
         /// <summary>
         /// Submits a quiz with user's answers, checks correctness, and saves the submission.
         /// </summary>
-        [HttpPost("submit")]
+        [HttpPost("add-submit")]
         public async Task<IActionResult> SubmitQuiz([FromBody] QuizSubmission submission)
         {
             try
@@ -378,7 +378,7 @@ namespace Duo.Api.Controllers
         /// <summary>
         /// Retrieves the quiz result (total questions, correct answers, and time taken) after submission.
         /// </summary>
-        [HttpGet("get-result")]
+        [HttpGet("get-quiz-result")]
         public async Task<IActionResult> GetQuizResult([FromQuery] int quizId)
         {
             try
@@ -410,7 +410,7 @@ namespace Duo.Api.Controllers
         /// Retrieves all available quiz.
         /// </summary>
         /// <returns>A list of available quizzes.</returns>
-        [HttpGet("get-available")]
+        [HttpGet("get-all-available")]
         public async Task<IActionResult> GetAvailableQuizzes()
         {
             try

--- a/Duo.Api/Controllers/SectionController.cs
+++ b/Duo.Api/Controllers/SectionController.cs
@@ -116,7 +116,7 @@ namespace Duo.Api.Controllers
         /// </summary>
         /// <param name="id">The ID of the section to retrieve.</param>
         /// <returns>ActionResult with the section data or error message.</returns>
-        [HttpGet("{id}")]
+        [HttpGet("get-section-by-id")]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
@@ -142,7 +142,7 @@ namespace Duo.Api.Controllers
         /// Gets a list of all sections in the system.
         /// </summary>
         /// <returns>ActionResult with list of sections or error message.</returns>
-        [HttpGet("list")]
+        [HttpGet("get-all")]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> ListSections()
@@ -193,7 +193,7 @@ namespace Duo.Api.Controllers
         /// <param name="id">The ID of the section to update.</param>
         /// <param name="request">The updated section data.</param>
         /// <returns>ActionResult with operation result.</returns>
-        [HttpPatch("{id}")]
+        [HttpPatch("patch")]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
@@ -227,7 +227,7 @@ namespace Duo.Api.Controllers
         /// </summary>
         /// <param name="roadmapId">The ID of the roadmap.</param>
         /// <returns>The count of sections.</returns>
-        [HttpGet("count-on-roadmap")]
+        [HttpGet("get-section-count-on-roadmap")]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> GetSectionCountOnRoadmap([FromQuery] int roadmapId)
@@ -249,7 +249,7 @@ namespace Duo.Api.Controllers
         /// </summary>
         /// <param name="roadmapId">The ID of the roadmap.</param>
         /// <returns>The last order number.</returns>
-        [HttpGet("last-from-roadmap")]
+        [HttpGet("get-last-from-roadmap")]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> GetLastOrderNumberFromRoadmap([FromQuery] int roadmapId)

--- a/Duo.Api/Controllers/TagController.cs
+++ b/Duo.Api/Controllers/TagController.cs
@@ -50,7 +50,7 @@ namespace Duo.Api.Controllers
         /// </summary>
         /// <param name="id">The ID of the tag to retrieve.</param>
         /// <returns>The tag if found; otherwise, NotFound.</returns>
-        [HttpGet("get")]
+        [HttpGet("get-tag-by-id")]
         public async Task<IActionResult> GetTag([FromQuery] int id)
         {
             try
@@ -73,7 +73,7 @@ namespace Duo.Api.Controllers
         /// Lists all tags in the database.
         /// </summary>
         /// <returns>A list of all tags.</returns>
-        [HttpGet("list")]
+        [HttpGet("get-all")]
         public async Task<IActionResult> ListTags()
         {
             try
@@ -92,7 +92,7 @@ namespace Duo.Api.Controllers
         /// </summary>
         /// <param name="updatedTag">The updated tag data, including TagId.</param>
         /// <returns>The updated tag if found; otherwise, NotFound.</returns>
-        [HttpPut("update")]
+        [HttpPut("modify")]
         public async Task<IActionResult> UpdateTag([FromForm] Tag updatedTag)
         {
             var tag = await repository.GetTagByIdAsync(updatedTag.TagId);

--- a/Duo/Services/CoinsServiceProxy.cs
+++ b/Duo/Services/CoinsServiceProxy.cs
@@ -27,7 +27,7 @@ namespace Duo.Services
         /// <returns>The user's coin balance, or 0 if an error occurs.</returns>
         public async Task<int> GetUserCoinBalanceAsync(int userId)
         {
-            var response = await httpClient.GetFromJsonAsync<int>($"{url}/api/coins/balance/{userId}");
+            var response = await httpClient.GetFromJsonAsync<int>($"{url}/api/Coins/get-balance/{userId}");
             return response;
         }
 
@@ -39,7 +39,7 @@ namespace Duo.Services
         /// <returns><c>true</c> if the operation is successful; otherwise, <c>false</c>.</returns>
         public async Task<bool> TrySpendingCoinsAsync(int userId, int cost)
         {
-            var response = await httpClient.PostAsJsonAsync($"{url}/api/coins/spend", new { UserId = userId, Cost = cost });
+            var response = await httpClient.PostAsJsonAsync($"{url}/api/Coins/add-spent-coins", new { UserId = userId, Cost = cost });
             return response.IsSuccessStatusCode;
         }
 
@@ -51,7 +51,7 @@ namespace Duo.Services
         /// <returns>A task that represents the asynchronous operation.</returns>
         public async Task AddCoinsAsync(int userId, int amount)
         {
-            var response = await httpClient.PostAsJsonAsync($"{url}/api/coins/add", new { UserId = userId, Amount = amount });
+            var response = await httpClient.PostAsJsonAsync($"{url}/api/Coins/add", new { UserId = userId, Amount = amount });
             response.EnsureSuccessStatusCode();
         }
 
@@ -63,7 +63,7 @@ namespace Duo.Services
         public async Task<bool> ApplyDailyLoginBonusAsync(int userId)
         {
             Console.WriteLine("daily bonus endpoint hit");
-            var response = await httpClient.PostAsJsonAsync($"{url}/api/coins/dailybonus", new { UserId = userId });
+            var response = await httpClient.PostAsJsonAsync($"{url}/api/Coins/get-dailybonus", new { UserId = userId });
             return response.IsSuccessStatusCode;
         }
     }

--- a/Duo/Services/CourseServiceProxy.cs
+++ b/Duo/Services/CourseServiceProxy.cs
@@ -22,27 +22,27 @@ namespace Duo.Services
 
         public async Task<List<Course>> GetAllCourses()
         {
-            return await httpClient.GetFromJsonAsync<List<Course>>($"{url}/api/course/list");
+            return await httpClient.GetFromJsonAsync<List<Course>>($"{url}/api/Course/list");
         }
 
         public async Task<Course> GetCourse(int courseId)
         {
-            return await httpClient.GetFromJsonAsync<Course>($"{url}/api/course/get?id={courseId}");
+            return await httpClient.GetFromJsonAsync<Course>($"{url}/api/Course/get?id={courseId}");
         }
 
         public async Task<List<Tag>> GetAllTags()
         {
-            return await httpClient.GetFromJsonAsync<List<Tag>>($"{url}/api/tag/list");
+            return await httpClient.GetFromJsonAsync<List<Tag>>($"{url}/api/Tag/get-all");
         }
 
         public async Task<List<Tag>> GetTagsForCourse(int courseId)
         {
-            return await httpClient.GetFromJsonAsync<List<Tag>>($"{url}/api/course/{courseId}/tags");
+            return await httpClient.GetFromJsonAsync<List<Tag>>($"{url}/api/Course/{courseId}/tags");
         }
 
         public async Task OpenModule(int userId, int moduleId)
         {
-            var response = await httpClient.PostAsJsonAsync($"{url}/api/module/open", new { UserId = userId, ModuleId = moduleId });
+            var response = await httpClient.PostAsJsonAsync($"{url}/api/Module/add-open-module", new { UserId = userId, ModuleId = moduleId });
             response.EnsureSuccessStatusCode();
         }
 
@@ -50,7 +50,7 @@ namespace Duo.Services
         {
             try
             {
-                return await httpClient.GetFromJsonAsync<List<Module>>($"{url}/api/module/list/by-course/{courseId}");
+                return await httpClient.GetFromJsonAsync<List<Module>>($"{url}/api/Module/get-all/by-course/{courseId}");
             }
             catch (HttpRequestException ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
             {
@@ -60,74 +60,74 @@ namespace Duo.Services
 
         public async Task<Module> GetModule(int moduleId)
         {
-            return await httpClient.GetFromJsonAsync<Module>($"{url}/api/module/{moduleId}");
+            return await httpClient.GetFromJsonAsync<Module>($"{url}/api/Module/get-module-by-id/{moduleId}");
         }
 
         public async Task<bool> IsModuleOpen(int userId, int moduleId)
         {
-            return await httpClient.GetFromJsonAsync<bool>($"{url}/api/module/isOpen?userId={userId}&moduleId={moduleId}");
+            return await httpClient.GetFromJsonAsync<bool>($"{url}/api/Module/get-open-status?userId={userId}&moduleId={moduleId}");
         }
 
         public async Task EnrollUser(int userId, int courseId)
         {
-            var response = await httpClient.PostAsJsonAsync($"{url}/api/course/enroll", new { userId, courseId });
+            var response = await httpClient.PostAsJsonAsync($"{url}/api/Course/enroll", new { userId, courseId });
             response.EnsureSuccessStatusCode();
         }
 
         public async Task<bool> IsUserEnrolled(int userId, int courseId)
         {
-            return await httpClient.GetFromJsonAsync<bool>($"{url}/api/course/is-enrolled?userId={userId}&courseId={courseId}");
+            return await httpClient.GetFromJsonAsync<bool>($"{url}/api/Course/is-enrolled?userId={userId}&courseId={courseId}");
         }
 
         public async Task CompleteModule(int userId, int moduleId)
         {
-            var response = await httpClient.PostAsJsonAsync($"{url}/api/module/complete", new { UserId = userId, ModuleId = moduleId });
+            var response = await httpClient.PostAsJsonAsync($"{url}/api/Module/complete", new { UserId = userId, ModuleId = moduleId });
             response.EnsureSuccessStatusCode();
         }
 
         public async Task<bool> IsCourseCompleted(int userId, int courseId)
         {
-            return await httpClient.GetFromJsonAsync<bool>($"{url}/api/course/isCompleted?userId={userId}&courseId={courseId}");
+            return await httpClient.GetFromJsonAsync<bool>($"{url}/api/Course/isCompleted?userId={userId}&courseId={courseId}");
         }
 
         public async Task MarkCourseAsCompleted(int userId, int courseId)
         {
-            var response = await httpClient.PostAsJsonAsync($"{url}/course/complete", new { UserId = userId, CourseId = courseId });
+            var response = await httpClient.PostAsJsonAsync($"{url}/api/Course/complete", new { UserId = userId, CourseId = courseId });
             response.EnsureSuccessStatusCode();
         }
 
         public async Task UpdateTimeSpent(int userId, int courseId, int seconds)
         {
-            var response = await httpClient.PutAsJsonAsync($"{url}/api/course/update-time", new { userId, courseId, seconds });
+            var response = await httpClient.PutAsJsonAsync($"{url}/api/Course/update-time", new { userId, courseId, seconds });
             response.EnsureSuccessStatusCode();
         }
 
         public async Task<int> GetTimeSpent(int userId, int courseId)
         {
-            return await httpClient.GetFromJsonAsync<int>($"{url}/api/course/get-time?userId={userId}&courseId={courseId}");
+            return await httpClient.GetFromJsonAsync<int>($"{url}/api/Course/get-time?userId={userId}&courseId={courseId}");
         }
 
         public async Task ClickModuleImage(int userId, int moduleId)
         {
-            var response = await httpClient.PostAsJsonAsync($"{url}/api/module/clickImage", new { UserId = userId, ModuleId = moduleId });
+            var response = await httpClient.PostAsJsonAsync($"{url}/api/Module/clickImage", new { UserId = userId, ModuleId = moduleId });
             response.EnsureSuccessStatusCode();
         }
 
         public async Task<bool> IsModuleImageClicked(int userId, int moduleId)
         {
-            return await httpClient.GetFromJsonAsync<bool>($"{url}/api/module/imageClicked?userId={userId}&moduleId={moduleId}");
+            return await httpClient.GetFromJsonAsync<bool>($"{url}/api/Module/imageClicked?userId={userId}&moduleId={moduleId}");
         }
 
         public async Task<bool> IsModuleAvailable(int userId, int moduleId)
         {
-            return await httpClient.GetFromJsonAsync<bool>($"{url}/api/module/isAvailable?userId={userId}&moduleId={moduleId}");
+            return await httpClient.GetFromJsonAsync<bool>($"{url}/api/Module/isAvailable?userId={userId}&moduleId={moduleId}");
         }
 
         public async Task<bool> IsModuleCompleted(int userId, int moduleId)
         {
             try
             {
-                var response = await httpClient.GetFromJsonAsync<bool>($"{url}/api/module/is-completed?userId={userId}&moduleId={moduleId}");
+                var response = await httpClient.GetFromJsonAsync<bool>($"{url}/api/Module/is-completed?userId={userId}&moduleId={moduleId}");
                 return response;
             }
             catch (Exception ex)
@@ -139,31 +139,31 @@ namespace Duo.Services
 
         public async Task<int> GetCompletedModulesCount(int userId, int courseId)
         {
-            return await httpClient.GetFromJsonAsync<int>($"{url}/api/course/completedModules?userId={userId}&courseId={courseId}");
+            return await httpClient.GetFromJsonAsync<int>($"{url}/api/Course/completedModules?userId={userId}&courseId={courseId}");
         }
 
         public async Task<int> GetRequiredModulesCount(int courseId)
         {
-            return await httpClient.GetFromJsonAsync<int>($"{url}/api/course/requiredModules?courseId={courseId}");
+            return await httpClient.GetFromJsonAsync<int>($"{url}/api/Course/requiredModules?courseId={courseId}");
         }
 
         public async Task<bool> ClaimCompletionReward(int userId, int courseId)
         {
-            var response = await httpClient.PostAsJsonAsync($"{url}/api/course/claimReward", new { UserId = userId, CourseId = courseId });
+            var response = await httpClient.PostAsJsonAsync($"{url}/api/Course/claim-completion", new { UserId = userId, CourseId = courseId });
             response.EnsureSuccessStatusCode();
             return true;
         }
 
         public async Task<bool> ClaimTimedReward(int userId, int courseId, int timeSpent)
         {
-            var response = await httpClient.PostAsJsonAsync($"{url}/api/course/claimTimedReward", new { UserId = userId, CourseId = courseId, TimeSpent = timeSpent });
+            var response = await httpClient.PostAsJsonAsync($"{url}/api/Course/claim-time", new { UserId = userId, CourseId = courseId, TimeSpent = timeSpent });
             response.EnsureSuccessStatusCode();
             return true;
         }
 
         public async Task<int> GetCourseTimeLimit(int courseId)
         {
-            return await httpClient.GetFromJsonAsync<int>($"{url}/api/course/timeLimit?courseId={courseId}");
+            return await httpClient.GetFromJsonAsync<int>($"{url}/api/Course/timeLimit?courseId={courseId}");
         }
 
         public async Task<bool> BuyBonusModule(int userId, int moduleId, int courseId)
@@ -178,7 +178,7 @@ namespace Duo.Services
                 Encoding.UTF8,
                 "application/json");
 
-            var response = await httpClient.PostAsync($"{url}/api/course/buyBonusModule", requestContent);
+            var response = await httpClient.PostAsync($"{url}/api/Course/buyBonusModule", requestContent);
             response.EnsureSuccessStatusCode();
             return true;
         }

--- a/Duo/Services/ExerciseServiceProxy.cs
+++ b/Duo/Services/ExerciseServiceProxy.cs
@@ -45,7 +45,7 @@ namespace Duo.Services
                     "FillInTheBlank" => JsonSerializer.Serialize((FillInTheBlankExercise)exercise, options),
                     _ => throw new NotSupportedException($"Exercise type '{exercise.Type}' is not supported.")
                 };
-                var response = await httpClient.PostAsync($"{url}api/Exercise", new StringContent(jsonExercise, Encoding.UTF8, "application/json"));
+                var response = await httpClient.PostAsync($"{url}api/Exercise/add", new StringContent(jsonExercise, Encoding.UTF8, "application/json"));
                 response.EnsureSuccessStatusCode();
 
                 // Deserialize the response to get the Id
@@ -74,7 +74,7 @@ namespace Duo.Services
 
         public async Task DeleteExercise(int exerciseId)
         {
-            var response = await httpClient.DeleteAsync($"{url}api/Exercise/{exerciseId}");
+            var response = await httpClient.DeleteAsync($"{url}api/Exercise/delete/{exerciseId}");
             response.EnsureSuccessStatusCode();
         }
 
@@ -82,7 +82,7 @@ namespace Duo.Services
         {
             try
             {
-                var response = await httpClient.GetAsync($"{url}api/Exercise");
+                var response = await httpClient.GetAsync($"{url}api/Exercise/get-all");
                 response.EnsureSuccessStatusCode();
 
                 string responseJson = await response.Content.ReadAsStringAsync();
@@ -131,7 +131,7 @@ namespace Duo.Services
 
         public async Task<List<Exercise>> GetAllExercisesFromExam(int examId)
         {
-            var response = await httpClient.GetAsync($"{url}api/Exercise/exam/{examId}");
+            var response = await httpClient.GetAsync($"{url}api/Exercise/get-exercises-by-exam/{examId}");
             response.EnsureSuccessStatusCode();
             string responseJson = await response.Content.ReadAsStringAsync();
             var exercises = JsonSerializationUtil.DeserializeExerciseList(responseJson);
@@ -140,7 +140,7 @@ namespace Duo.Services
 
         public async Task<List<Exercise>> GetAllExercisesFromQuiz(int quizId)
         {
-            var response = await httpClient.GetAsync($"{url}api/Exercise/quiz/{quizId}");
+            var response = await httpClient.GetAsync($"{url}api/Exercise/get-exercises-by-quiz/{quizId}");
             response.EnsureSuccessStatusCode();
             string responseJson = await response.Content.ReadAsStringAsync();
             var exercises = JsonSerializationUtil.DeserializeExerciseList(responseJson);
@@ -149,7 +149,7 @@ namespace Duo.Services
 
         public async Task<Exercise?> GetExerciseById(int exerciseId)
         {
-            var response = await httpClient.GetAsync($"{url}api/Exercise/{exerciseId}");
+            var response = await httpClient.GetAsync($"{url}api/Exercise/get-exercise-by-id");
             response.EnsureSuccessStatusCode();
             var exercise = await response.Content.ReadFromJsonAsync<Exercise>();
             return exercise ?? throw new InvalidOperationException("Exercise not found.");

--- a/Duo/Services/QuizServiceProxy.cs
+++ b/Duo/Services/QuizServiceProxy.cs
@@ -28,7 +28,7 @@ namespace Duo.Services
 
         public async Task<List<Quiz>> GetAsync()
         {
-            var result = await httpClient.GetAsync($"{url}quiz/list");
+            var result = await httpClient.GetAsync($"{url}Quiz/get-all");
             result.EnsureSuccessStatusCode();
             string responseJson = await result.Content.ReadAsStringAsync();
             var quizzes = new List<Quiz>();
@@ -44,7 +44,7 @@ namespace Duo.Services
 
         public async Task<List<Quiz>> GetAllAvailableQuizzesAsync()
         {
-            var result = await httpClient.GetAsync($"{url}quiz/get-available");
+            var result = await httpClient.GetAsync($"{url}Quiz/get-all-available");
             if (result == null)
             {
                 throw new QuizServiceProxyException("Received null response when fetching quiz list.");
@@ -66,7 +66,7 @@ namespace Duo.Services
 
         public async Task<List<Exam>> GetAllExams()
         {
-            var result = await httpClient.GetAsync($"{url}exam/list");
+            var result = await httpClient.GetAsync($"{url}Exam/get-all");
             if (result == null)
             {
                 throw new QuizServiceProxyException("Received null response when fetching available exams.");
@@ -88,7 +88,7 @@ namespace Duo.Services
 
         public async Task<List<Exam>> GetAllAvailableExamsAsync()
         {
-            var result = await httpClient.GetAsync($"{url}exam/get-available");
+            var result = await httpClient.GetAsync($"{url}Exam/get-all-available");
             result.EnsureSuccessStatusCode();
             string responseJson = await result.Content.ReadAsStringAsync();
             var exams = new List<Exam>();
@@ -104,7 +104,7 @@ namespace Duo.Services
 
         public async Task<Quiz> GetQuizByIdAsync(int id)
         {
-            var result = await httpClient.GetAsync($"{url}quiz/get?id={id}");
+            var result = await httpClient.GetAsync($"{url}Quiz/get-quiz-by-id?id={id}");
             result.EnsureSuccessStatusCode();
             string responseJson = await result.Content.ReadAsStringAsync();
             return JsonSerializationUtil.DeserializeQuiz(responseJson);
@@ -112,7 +112,7 @@ namespace Duo.Services
 
         public async Task<Exam> GetExamByIdAsync(int id)
         {
-            var result = await httpClient.GetAsync($"{url}exam/get?id={id}");
+            var result = await httpClient.GetAsync($"{url}Exam/get-exam-by-id?id={id}");
             result.EnsureSuccessStatusCode();
             string responseJson = await result.Content.ReadAsStringAsync();
             return JsonSerializationUtil.DeserializeExamWithTypedExercises(responseJson);
@@ -120,45 +120,45 @@ namespace Duo.Services
 
         public async Task<List<Quiz>> GetAllQuizzesFromSectionAsync(int sectionId)
         {
-            var result = await httpClient.GetFromJsonAsync<List<Quiz>>($"{url}quiz/get-all-section?sectionId={sectionId}");
+            var result = await httpClient.GetFromJsonAsync<List<Quiz>>($"{url}Quiz/get-all-by-section?sectionId={sectionId}");
             return result ?? throw new QuizServiceProxyException($"Received null response for section {sectionId} quizzes.");
         }
 
         public async Task<int> CountQuizzesFromSectionAsync(int sectionId)
         {
-            var result = await httpClient.GetFromJsonAsync<int?>($"{url}quiz/count-from-section?sectionId={sectionId}");
+            var result = await httpClient.GetFromJsonAsync<int?>($"{url}Quiz/count-quizzes-from-section?sectionId={sectionId}");
             return result ?? throw new QuizServiceProxyException($"Received null response when counting quizzes in section {sectionId}.");
         }
 
         public async Task<int> LastOrderNumberFromSectionAsync(int sectionId)
         {
-            var result = await httpClient.GetFromJsonAsync<int?>($"{url}quiz/last-order?sectionId={sectionId}");
+            var result = await httpClient.GetFromJsonAsync<int?>($"{url}Quiz/get-last-order-number-from-section?sectionId={sectionId}");
             return result ?? throw new QuizServiceProxyException($"Received null response when getting last order number from section {sectionId}.");
         }
 
         public async Task<Exam> GetExamFromSectionAsync(int sectionId)
         {
-            var result = await httpClient.GetFromJsonAsync<Exam>($"{url}exam/get-from-section?sectionId={sectionId}");
+            var result = await httpClient.GetFromJsonAsync<Exam>($"{url}Exam/get-exams-from-section?sectionId={sectionId}");
             return result ?? throw new QuizServiceProxyException($"Received null response for exam from section {sectionId}.");
         }
 
         public async Task DeleteQuizAsync(int quizId)
         {
-            var response = await httpClient.DeleteAsync($"{url}quiz/delete?id={quizId}");
+            var response = await httpClient.DeleteAsync($"{url}Quiz/delete?id={quizId}");
             response.EnsureSuccessStatusCode();
         }
 
         public async Task UpdateQuizAsync(Quiz quiz)
         {
             string serialized = JsonSerializationUtil.SerializeQuiz(quiz);
-            var response = await httpClient.PutAsync($"{url}quiz/update", new StringContent(serialized, Encoding.UTF8, "application/json"));
+            var response = await httpClient.PutAsync($"{url}Quiz/modify", new StringContent(serialized, Encoding.UTF8, "application/json"));
             response.EnsureSuccessStatusCode();
         }
 
         public async Task CreateQuizAsync(Quiz quiz)
         {
             string serialized = JsonSerializationUtil.SerializeQuiz(quiz);
-            var response = await httpClient.PostAsync($"{url}quiz/add", new StringContent(serialized, Encoding.UTF8, "application/json"));
+            var response = await httpClient.PostAsync($"{url}Quiz/add", new StringContent(serialized, Encoding.UTF8, "application/json"));
             response.EnsureSuccessStatusCode();
         }
 
@@ -170,7 +170,7 @@ namespace Duo.Services
             {
                 formData.Add(new StringContent(exerciseId.ToString()), "exercises");
             }
-            var response = await httpClient.PostAsync($"{url}quiz/add-exercises", formData);
+            var response = await httpClient.PostAsync($"{url}Quiz/add-exercises", formData);
             response.EnsureSuccessStatusCode();
         }
 
@@ -179,7 +179,7 @@ namespace Duo.Services
             var formData = new MultipartFormDataContent();
             formData.Add(new StringContent(quizId.ToString()), "quizId");
             formData.Add(new StringContent(exerciseId.ToString()), "exerciseId");
-            var response = await httpClient.PostAsync($"{url}quiz/add-exercise", formData);
+            var response = await httpClient.PostAsync($"{url}Quiz/add-exercise", formData);
             response.EnsureSuccessStatusCode();
         }
 
@@ -188,50 +188,50 @@ namespace Duo.Services
             var formData = new MultipartFormDataContent();
             formData.Add(new StringContent(examId.ToString()), "examId");
             formData.Add(new StringContent(exerciseId.ToString()), "exerciseId");
-            var response = await httpClient.PostAsync($"{url}exam/add-exercise", formData);
+            var response = await httpClient.PostAsync($"{url}Exam/add-exercise", formData);
             response.EnsureSuccessStatusCode();
         }
 
         public async Task RemoveExerciseFromQuizAsync(int quizId, int exerciseId)
         {
-            var response = await httpClient.DeleteAsync($"{url}quiz/remove-exercise?quizId={quizId}&exerciseId={exerciseId}");
+            var response = await httpClient.DeleteAsync($"{url}Quiz/delete-exercise?quizId={quizId}&exerciseId={exerciseId}");
             response.EnsureSuccessStatusCode();
         }
 
         public async Task RemoveExerciseFromExamAsync(int examId, int exerciseId)
         {
-            var response = await httpClient.DeleteAsync($"{url}exam/remove-exercise?examId={examId}&exerciseId={exerciseId}");
+            var response = await httpClient.DeleteAsync($"{url}Exam/remove-exercise?examId={examId}&exerciseId={exerciseId}");
             response.EnsureSuccessStatusCode();
         }
 
         public async Task DeleteExamAsync(int examId)
         {
-            var response = await httpClient.DeleteAsync($"{url}exam/delete?id={examId}");
+            var response = await httpClient.DeleteAsync($"{url}Exam/delete?id={examId}");
             response.EnsureSuccessStatusCode();
         }
 
         public async Task UpdateExamAsync(Exam exam)
         {
-            var response = await httpClient.PutAsJsonAsync($"{url}exam/update", exam);
+            var response = await httpClient.PutAsJsonAsync($"{url}Exam/update", exam);
             response.EnsureSuccessStatusCode();
         }
 
         public async Task CreateExamAsync(Exam exam)
         {
             string serialized = JsonSerializationUtil.SerializeExamWithTypedExercises(exam);
-            var response = await httpClient.PostAsync($"{url}exam/add", new StringContent(serialized, Encoding.UTF8, "application/json"));
+            var response = await httpClient.PostAsync($"{url}Exam/add", new StringContent(serialized, Encoding.UTF8, "application/json"));
             response.EnsureSuccessStatusCode();
         }
 
         public async Task<QuizResult> GetResultAsync(int quizId)
         {
-            var result = await httpClient.GetFromJsonAsync<QuizResult>($"{url}quiz/get-result?quizId={quizId}");
+            var result = await httpClient.GetFromJsonAsync<QuizResult>($"{url}Quiz/get-quiz-result?quizId={quizId}");
             return result ?? throw new QuizServiceProxyException($"Received null response for result of quiz {quizId}.");
         }
 
         public async Task SubmitQuizAsync(QuizSubmission submission)
         {
-            var response = await httpClient.PostAsJsonAsync($"{url}quiz/submit", submission);
+            var response = await httpClient.PostAsJsonAsync($"{url}Quiz/add-submit", submission);
             response.EnsureSuccessStatusCode();
         }
     }

--- a/Duo/Services/SectionServiceProxy.cs
+++ b/Duo/Services/SectionServiceProxy.cs
@@ -40,7 +40,7 @@ namespace Duo.Services
             string json = JsonSerializer.Serialize(dto, new JsonSerializerOptions { WriteIndented = true });
             var content = new StringContent(json, Encoding.UTF8, "application/json");
             var response = await this.httpClient.PostAsync(
-                    $"{this.url}/api/section/add",
+                    $"{this.url}/api/Section/add",
                     content).ConfigureAwait(false);
 
             response.EnsureSuccessStatusCode();
@@ -56,21 +56,21 @@ namespace Duo.Services
 
         public async Task<int> CountSectionsFromRoadmap(int roadmapId)
         {
-            var response = await httpClient.GetAsync($"{url}/api/sections/count/{roadmapId}");
+            var response = await httpClient.GetAsync($"{url}/api/Section/get-section-count-on-roadmap");
             response.EnsureSuccessStatusCode();
             return await response.Content.ReadFromJsonAsync<int>();
         }
 
         public async Task DeleteSection(int sectionId)
         {
-            var response = await this.httpClient.DeleteAsync($"{url}/api/section/{sectionId}");
+            var response = await this.httpClient.DeleteAsync($"{url}/api/Section/{sectionId}");
             response.EnsureSuccessStatusCode();
         }
 
         public async Task<List<Section>> GetAllSections()
         {
             var list = await this.httpClient
-                    .GetFromJsonAsync<List<Section>>($"{url}/api/section/list")
+                    .GetFromJsonAsync<List<Section>>($"{url}/api/Section/get-all")
                     .ConfigureAwait(false);
             if (list == null)
             {
@@ -100,7 +100,7 @@ namespace Duo.Services
 
         public async Task<Section> GetSectionById(int sectionId)
         {
-            var response = await httpClient.GetAsync($"{url}/api/Section/{sectionId}?id={sectionId}");
+            var response = await httpClient.GetAsync($"{url}/api/Section/get-section-by-id");
             response.EnsureSuccessStatusCode();
             var section = await response.Content.ReadFromJsonAsync<Section>();
             if (section == null)
@@ -112,14 +112,14 @@ namespace Duo.Services
 
         public async Task<int> LastOrderNumberFromRoadmap(int roadmapId)
         {
-            var response = await httpClient.GetAsync($"{url}/api/sections/lastordernumber/{roadmapId}");
+            var response = await httpClient.GetAsync($"{url}/api/Section/get-last-from-roadmap");
             response.EnsureSuccessStatusCode();
             return await response.Content.ReadFromJsonAsync<int>();
         }
 
         public async Task UpdateSection(Section section)
         {
-            var response = await httpClient.PutAsJsonAsync($"{url}/api/sections/update", section);
+            var response = await httpClient.PutAsJsonAsync($"{url}/api/Section/patch", section);
             response.EnsureSuccessStatusCode();
         }
 

--- a/Duo/Services/UserServiceProxy.cs
+++ b/Duo/Services/UserServiceProxy.cs
@@ -93,7 +93,7 @@ namespace Duo.Services
                 throw new ArgumentNullException(nameof(user));
             }
 
-            var response = await httpClient.PutAsJsonAsync($"{BaseUrl}/update", user);
+            var response = await httpClient.PutAsJsonAsync($"{BaseUrl}", user);
             response.EnsureSuccessStatusCode();
         }
     }


### PR DESCRIPTION
#### PR Classification
API change to improve route naming consistency and clarity.

#### PR Summary
This pull request updates the route paths in various controller classes and service proxies to follow a more descriptive naming convention, enhancing API usability and maintainability.
- **CoinsController.cs**: Changed routes from `balance/{userId}` to `get-balance/{userId}` and `spend` to `add-spent-coins`.
- **ExamController.cs**: Updated routes to be more descriptive, e.g., `get` to `get-exam-by-id`.
- **ExerciseController.cs**: Modified routes such as `quiz/{quizId}` to `get-exercises-by-quiz/{quizId}`.
- **ModuleController.cs**: Changed routes like `list` to `get-all` and `is-completed` to `get-completion-status`.
- **Service Proxies**: Updated API calls in `CoinsServiceProxy`, `CourseServiceProxy`, and others to match the new route paths in their respective controllers.
