### PR TITLE
Fixed module completing and coins

### DIFF
--- a/Duo.Api/Controllers/ModuleController.cs
+++ b/Duo.Api/Controllers/ModuleController.cs
@@ -307,7 +307,7 @@ namespace Duo.Api.Controllers
             {
                 if (!data.TryGetValue("userId", out var userIdObj) || !data.TryGetValue("moduleId", out var moduleIdObj))
                 {
-                    return this.BadRequest("Missing userId or courseId");
+                    return this.BadRequest("Missing userId or moduleId");
                 }
 
                 var userId = ((JsonElement)data["userId"]).GetInt32();

--- a/Duo.Api/Controllers/ModuleController.cs
+++ b/Duo.Api/Controllers/ModuleController.cs
@@ -319,7 +319,11 @@ namespace Duo.Api.Controllers
             }
             catch (Exception e)
             {
-                return BadRequest(new { message = e.Message });
+                // Log the exception internally
+                Console.Error.WriteLine($"Error in CompleteModule: {e}");
+                
+                // Return a generic error message to the client
+                return BadRequest(new { message = "An error occurred while processing your request." });
             }
         }
     }

--- a/Duo.Api/Controllers/ModuleController.cs
+++ b/Duo.Api/Controllers/ModuleController.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
 using Duo.Api.DTO.Requests;
 using Duo.Api.Models;
 using Duo.Api.Repositories;
@@ -296,5 +297,30 @@ namespace Duo.Api.Controllers
             }
         }
         #endregion
+
+        [HttpPost("complete")]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        public async Task<IActionResult> CompleteModule([FromBody] Dictionary<string, object> data)
+        {
+            try
+            {
+                if (!data.TryGetValue("userId", out var userIdObj) || !data.TryGetValue("moduleId", out var moduleIdObj))
+                {
+                    return this.BadRequest("Missing userId or courseId");
+                }
+
+                var userId = ((JsonElement)data["userId"]).GetInt32();
+                var moduleId = ((JsonElement)data["moduleId"]).GetInt32();
+
+                await repository.CompleteModuleAsync(userId, moduleId);
+
+                return Ok(new { message = "Module completed successfully!" });
+            }
+            catch (Exception e)
+            {
+                return BadRequest(new { message = e.Message });
+            }
+        }
     }
 }

--- a/Duo.Api/Repositories/Repository.cs
+++ b/Duo.Api/Repositories/Repository.cs
@@ -262,7 +262,7 @@ namespace Duo.Api.Repositories
                     UserId = userId,
                     ModuleId = moduleId,
                     Status = "completed",
-                    ImageClicked = true,
+                    ImageClicked = false,
                 };
                 context.UserProgresses.Add(newProgress);
                 await context.SaveChangesAsync();

--- a/Duo.Api/Repositories/Repository.cs
+++ b/Duo.Api/Repositories/Repository.cs
@@ -262,9 +262,10 @@ namespace Duo.Api.Repositories
                     UserId = userId,
                     ModuleId = moduleId,
                     Status = "completed",
-                    ImageClicked = false
+                    ImageClicked = true,
                 };
                 context.UserProgresses.Add(newProgress);
+                await context.SaveChangesAsync();
             }
 
             await Task.CompletedTask;

--- a/Duo/ViewModels/ModuleViewModel.cs
+++ b/Duo/ViewModels/ModuleViewModel.cs
@@ -73,6 +73,8 @@ namespace Duo.ViewModels
                     }
                 };
                 OnPropertyChanged(nameof(IsCompleted));
+
+                await LoadCoinBalanceAsync();
             }
             catch (Exception ex)
             {
@@ -112,7 +114,7 @@ namespace Duo.ViewModels
         // Async method to load and update the CoinBalance
         public async Task LoadCoinBalanceAsync()
         {
-            CoinBalance = await coinsService.GetCoinBalanceAsync(0);
+            CoinBalance = await coinsService.GetCoinBalanceAsync(UserId);
         }
 
         private bool CanCompleteModule(object? parameter)


### PR DESCRIPTION
This pull request introduces a new endpoint for marking a module as completed, updates the repository to persist these changes, and enhances the `ModuleViewModel` to handle user-specific coin balances. Below is a breakdown of the most important changes:

### New Endpoint for Module Completion:

* [`Duo.Api/Controllers/ModuleController.cs`](diffhunk://#diff-8739cc1d62ec4db8fa35d35db31a41581cb470248b8e5fa8c88d501fcb65e9ddR300-R324): Added a new `POST` endpoint (`CompleteModule`) that allows users to mark a module as completed by providing `userId` and `moduleId` in the request body. The endpoint validates the input, interacts with the repository, and returns appropriate responses.

### Repository Updates:

* [`Duo.Api/Repositories/Repository.cs`](diffhunk://#diff-c289686ff14a6189ca019b7be48d801bcec670be0b9bbeab8a175b36bd09e7c5L265-R268): Updated the `CompleteModuleAsync` method to persist changes to the database by adding a call to `SaveChangesAsync`. This ensures that the module completion status is properly saved.

### ViewModel Enhancements:

* [`Duo/ViewModels/ModuleViewModel.cs`](diffhunk://#diff-0b30610314882379109d341cfa2e6d41c2c485be74a7e7ceb0402548861deb04L115-R117): Modified the `LoadCoinBalanceAsync` method to use the `UserId` property instead of a hardcoded value, ensuring that the correct coin balance is fetched for the current user.
* [`Duo/ViewModels/ModuleViewModel.cs`](diffhunk://#diff-0b30610314882379109d341cfa2e6d41c2c485be74a7e7ceb0402548861deb04R76-R77): Enhanced the `InitializeAsync` method to include a call to `LoadCoinBalanceAsync`, ensuring that the coin balance is updated when the view model is initialized.

### Minor Code Adjustments:

* [`Duo.Api/Controllers/ModuleController.cs`](diffhunk://#diff-8739cc1d62ec4db8fa35d35db31a41581cb470248b8e5fa8c88d501fcb65e9ddR2): Added `System.Text.Json` to handle JSON deserialization for the new endpoint.